### PR TITLE
feat(ui): refine layout and allow 2gb uploads

### DIFF
--- a/gpu_etl_pipeline/utils.py
+++ b/gpu_etl_pipeline/utils.py
@@ -4,7 +4,10 @@ utils.py（GPU 版通用工具）
 - 記憶體監控與暫存 flush（支援 cuDF / pandas）
 - 自動偵測 cudf/cupy 是否可用，無 GPU 時退回 CPU 以確保流程不中斷
 """
-import psutil
+try:
+    import psutil
+except Exception:  # pragma: no cover - fallback when psutil not installed
+    from ui_pages import psutil_stub as psutil  # type: ignore
 import gc
 import os
 import tempfile

--- a/ui_app.py
+++ b/ui_app.py
@@ -1,14 +1,38 @@
 import streamlit as st
-from ui_pages import training_ui, gpu_etl_ui, inference_ui, folder_monitor_ui, visualization_ui
+from ui_pages import (
+    training_ui,
+    gpu_etl_ui,
+    inference_ui,
+    folder_monitor_ui,
+    visualization_ui,
+)
+
+st.set_page_config(
+    page_title="D-FLARE Dashboard",
+    page_icon=":bar_chart:",
+    layout="wide",
+)
+st.set_option("server.maxUploadSize", 2 * 1024)
+
+st.markdown(
+    """
+    <style>
+    .stApp {
+        background-color: #f5f7fa;
+    }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
 
 PAGES = {
-    "Training Pipeline": training_ui.app,
-    "GPU ETL Pipeline": gpu_etl_ui.app,
-    "Model Inference": inference_ui.app,
-    "Folder Monitor": folder_monitor_ui.app,
-    "Visualization": visualization_ui.app,
+    "🧠 Training Pipeline": training_ui.app,
+    "⚙️ GPU ETL Pipeline": gpu_etl_ui.app,
+    "🔍 Model Inference": inference_ui.app,
+    "📂 Folder Monitor": folder_monitor_ui.app,
+    "📊 Visualization": visualization_ui.app,
 }
 
-st.sidebar.title("Navigation")
+st.sidebar.title("📚 Navigation")
 selection = st.sidebar.radio("Go to", list(PAGES.keys()))
 PAGES[selection]()

--- a/ui_pages/gpu_etl_ui.py
+++ b/ui_pages/gpu_etl_ui.py
@@ -3,7 +3,12 @@ from gpu_etl_pipeliner import run_pipeline
 
 def app() -> None:
     st.title("GPU ETL Pipeline")
-    uploaded_files = st.file_uploader("Upload log files", type=["csv", "txt", "gz"], accept_multiple_files=True)
+    uploaded_files = st.file_uploader(
+        "Upload log files",
+        type=["csv", "txt", "gz"],
+        accept_multiple_files=True,
+        help="Max file size: 2GB per file",
+    )
     do_clean = st.checkbox("Run cleaning", value=True)
     do_map = st.checkbox("Run mapping", value=True)
     do_fe = st.checkbox("Run feature engineering", value=True)

--- a/ui_pages/inference_ui.py
+++ b/ui_pages/inference_ui.py
@@ -8,9 +8,21 @@ import joblib
 
 def app() -> None:
     st.title("Model Inference")
-    data_file = st.file_uploader("Upload data CSV", type=["csv"])
-    binary_model = st.file_uploader("Upload binary model", type=["pkl", "joblib"])
-    multi_model = st.file_uploader("Upload multiclass model", type=["pkl", "joblib"])
+    data_file = st.file_uploader(
+        "Upload data CSV",
+        type=["csv"],
+        help="Max file size: 2GB",
+    )
+    binary_model = st.file_uploader(
+        "Upload binary model",
+        type=["pkl", "joblib"],
+        help="Max file size: 2GB",
+    )
+    multi_model = st.file_uploader(
+        "Upload multiclass model",
+        type=["pkl", "joblib"],
+        help="Max file size: 2GB",
+    )
     if st.button("Run inference"):
         if data_file is None or binary_model is None or multi_model is None:
             st.error("Please upload data and model files")

--- a/ui_pages/training_ui.py
+++ b/ui_pages/training_ui.py
@@ -7,7 +7,11 @@ from training_pipeline.pipeline_main import TrainingPipeline
 
 def app() -> None:
     st.title("Training Pipeline")
-    uploaded_file = st.file_uploader("Upload training CSV", type=["csv"])
+    uploaded_file = st.file_uploader(
+        "Upload training CSV",
+        type=["csv"],
+        help="Max file size: 2GB",
+    )
     task_type = st.selectbox("Task type", ["binary", "multiclass"])
     optuna_enabled = st.checkbox("Enable Optuna", value=False)
     optimize_base = st.checkbox("Optimize base models", value=False)

--- a/ui_pages/visualization_ui.py
+++ b/ui_pages/visualization_ui.py
@@ -9,7 +9,11 @@ def app() -> None:
     st.title("Prediction Visualization")
     df = st.session_state.get("prediction_results")
     if df is None:
-        uploaded = st.file_uploader("Upload prediction CSV", type=["csv"])
+        uploaded = st.file_uploader(
+            "Upload prediction CSV",
+            type=["csv"],
+            help="Max file size: 2GB",
+        )
         if uploaded is not None:
             df = pd.read_csv(uploaded)
             st.session_state["prediction_results"] = df


### PR DESCRIPTION
## Summary
- enhance Streamlit dashboard style with wide layout, icons, and custom background
- raise file upload limit to 2GB and annotate all upload widgets
- allow GPU utils to fall back to psutil stub when psutil is unavailable

## Testing
- `pip install psutil`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abbe37a6cc83208f4b14ae41f0d174

## Sourcery 总结

通过增强布局、样式和图标来优化用户界面，将文件上传限制提升至 2GB 并添加说明，以及使 GPU 工具在缺少 psutil 时也能稳定运行。

新功能：
- 配置 Streamlit 面板，采用宽布局、页面图标和自定义背景颜色
- 在侧边栏导航和页面标题中添加表情符号图标
- 将最大文件上传大小增加到 2GB，并为上传小部件添加帮助文本

错误修复：
- 允许 GPU 工具在 psutil 不可用时回退到 psutil 存根

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the UI by enhancing layout, styling, and icons, boost file upload limit to 2GB with annotations, and make GPU utilities robust to missing psutil

New Features:
- Configure Streamlit dashboard with wide layout, page icon, and custom background color
- Add emoji icons to sidebar navigation and page titles
- Increase max file upload size to 2GB and annotate upload widgets with help text

Bug Fixes:
- Enable GPU utilities to fallback to a psutil stub when psutil is unavailable

</details>