### PR TITLE
Remove runtime Streamlit maxUploadSize setting

### DIFF
--- a/ui_app.py
+++ b/ui_app.py
@@ -12,9 +12,7 @@ st.set_page_config(
     page_icon=":bar_chart:",
     layout="wide",
 )
-
-st.set_option("server.maxUploadSize", 2 * 1024)
-
+# Upload size limit configured in .streamlit/config.toml
 
 st.markdown(
     """


### PR DESCRIPTION
## Summary
- Drop unsupported `st.set_option` call for `server.maxUploadSize` and rely on configuration file.
- Document config usage in `ui_app.py`.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abc9a1ff448320af602aad86b4f47c