### PR TITLE
Remove deprecated XGBoost predictor parameter to stop warnings

### DIFF
--- a/training_pipeline/combo_optimizer.py
+++ b/training_pipeline/combo_optimizer.py
@@ -68,7 +68,7 @@ def _as_cpu_estimator(est):
     # XGBoost sklearn API
     if "xgb" in name or "xgboost" in name:
         # 若你要 GPU 訓練，這裡可依需求調整。為了 ensemble 安全，仍以 CPU 推論/重訓。
-        _set_if_has(e, tree_method="hist", predictor="cpu_predictor", n_jobs=1, verbosity=0)
+        _set_if_has(e, tree_method="hist", device="cpu", n_jobs=1, verbosity=0)
 
     return e
 

--- a/training_pipeline/model_builder.py
+++ b/training_pipeline/model_builder.py
@@ -40,7 +40,6 @@ class ModelBuilder:
         # -------- 降噪（不影響錯誤拋出）---------
         warnings.filterwarnings("ignore", category=UserWarning, module="xgboost")
         warnings.filterwarnings("ignore", message=".*gpu_hist.*deprecated.*")
-        warnings.filterwarnings("ignore", message='.*Parameters: { "predictor" } are not used.*')
         warnings.filterwarnings("ignore", message=".*Falling back to prediction using DMatrix.*")
         warnings.filterwarnings("ignore", message=".*No further splits with positive gain.*")
 
@@ -129,7 +128,6 @@ class ModelBuilder:
                     "colsample_bytree": trial.suggest_float("colsample_bytree", 0.5, 1.0),
                     "tree_method": "hist",
                     "device": "cuda",
-                    "predictor": "gpu_predictor",
                     "random_state": rng,
                     "n_jobs": -1,
                 }
@@ -153,7 +151,6 @@ class ModelBuilder:
                 **study_xgb.best_params,
                 "tree_method": "hist",
                 "device": "cuda",
-                "predictor": "gpu_predictor",
                 "n_jobs": -1,
                 "random_state": rng,
                 **(
@@ -387,7 +384,6 @@ class ModelBuilder:
             p.update(tuned["XGB"])
         p.setdefault("tree_method", "hist")
         p.setdefault("device", "cuda")
-        p.setdefault("predictor", "gpu_predictor")
         p.setdefault("n_jobs", -1)
         p.setdefault("random_state", self.config.get("RANDOM_STATE", 42))
         p.update(task_args["XGB"])


### PR DESCRIPTION
## Summary
- stop supplying deprecated `predictor` parameter to XGBoost
- ensure ensemble fallback forces CPU device instead of unused predictor

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abcb19f4cc8320a2ee7bc7ebd9392c

## Sourcery 总结

移除已废弃的 XGBoost `predictor` 参数，并更新 CPU 回退机制以使用 `device` 设置

Bug 修复:
- 移除已废弃的 `predictor` 参数以抑制相关警告

功能增强:
- 更新集成模型 CPU 回退机制以使用 `device="cpu"` 而非 `predictor`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove deprecated XGBoost predictor parameter and update CPU fallback to use the ‘device’ setting

Bug Fixes:
- Remove deprecated ‘predictor’ parameter to suppress related warnings

Enhancements:
- Update ensemble CPU fallback to use device="cpu" instead of predictor

</details>