### PR TITLE
Fix CSS braces causing NameError in UI

### DIFF
--- a/ui_app.py
+++ b/ui_app.py
@@ -27,9 +27,8 @@ st.set_page_config(
 st.markdown(
     f"""
     <style>
-
     .stApp {{
-        background-color: #f3f4f6;
+        background-color: #f5f7fa;
     }}
     div[data-testid="stSidebar"] {{
         width: {sidebar_width};
@@ -55,20 +54,6 @@ st.markdown(
     .menu-collapsed .nav-link {{
         justify-content: center;
     }}
-=======
-    .stApp {
-        background-color: #f5f7fa;
-    }
-    /* sidebar base style */
-    .menu-expanded .nav-link span {
-        display: inline-block;
-    }
-    .menu-collapsed .nav-link span {
-        display: none;
-    }
-    .menu-collapsed .nav-link {
-        justify-content: center;
-    }
 
     </style>
     """,


### PR DESCRIPTION
## Summary
- Correct Streamlit UI CSS block by escaping braces and removing merge artifacts
- Set app background color and sidebar styles without causing NameError

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad489b61288320a5f22f42b358fc36

## Sourcery 总结

修复UI CSS块中的语法错误，通过转义大括号和移除合并冲突遗留物，并调整应用背景和侧边栏样式。

Bug 修复：
- 转义Streamlit markdown CSS中的大括号以防止NameError
- 移除CSS块中剩余的合并冲突标记

改进：
- 将应用背景颜色更新为 #f5f7fa
- 优化侧边栏导航样式

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix syntax errors in UI CSS block by escaping braces and removing merge conflict artifacts, and adjust app background and sidebar styles

Bug Fixes:
- Escape braces in Streamlit markdown CSS to prevent NameError
- Remove leftover merge conflict markers from CSS block

Enhancements:
- Update app background color to #f5f7fa
- Refine sidebar navigation styles

</details>