### PR TITLE
Fix label encoding and ensemble indexing

### DIFF
--- a/training_pipeline/combo_optimizer.py
+++ b/training_pipeline/combo_optimizer.py
@@ -176,7 +176,7 @@ class ComboOptimizer:
         ens.setdefault("OPTUNA_TRIALS", 30)
         ens.setdefault("WEIGHT_MODE", "dirichlet")
         ens.setdefault("MODE", "free")
-        ens.setdefault("MIN_MODELS", 1)
+        ens.setdefault("MIN_MODELS", 2)
         ens.setdefault("MAX_MODELS", None)
         ens.setdefault("PRUNING", True)
         ens.setdefault("DIRECTION", "maximize")
@@ -260,7 +260,7 @@ class ComboOptimizer:
             n_trials=int(self.ens.get("OPTUNA_TRIALS", 30)),
             weight_mode=self.ens.get("WEIGHT_MODE", "dirichlet"),
             mode=self.ens.get("MODE", "free"),
-            min_models=int(self.ens.get("MIN_MODELS", 1)),
+            min_models=int(self.ens.get("MIN_MODELS", 2)),
             max_models=self.ens.get("MAX_MODELS"),
             pruning=bool(self.ens.get("PRUNING", True)),
             direction=self.ens.get("DIRECTION", "maximize"),
@@ -536,7 +536,7 @@ def run_ensemble(
         n_trials=cfg.get("OPTUNA_TRIALS", 50),
         weight_mode=cfg.get("WEIGHT_MODE", "dirichlet"),
         mode=mode,
-        min_models=cfg.get("MIN_MODELS", 1),
+        min_models=cfg.get("MIN_MODELS", 2),
         max_models=cfg.get("MAX_MODELS", None),
         pruning=cfg.get("PRUNING", True),
         direction=cfg.get("DIRECTION", "maximize"),

--- a/training_pipeline/evaluator.py
+++ b/training_pipeline/evaluator.py
@@ -36,38 +36,41 @@ class Evaluator:
         if name:
             print(f"\n==================== [ {name} 評估結果 ] ====================")
 
+        X_eval = X.to_numpy() if hasattr(X, "to_numpy") else np.asarray(X)
+        y_true_np = y_true.to_numpy().reshape(-1) if hasattr(y_true, "to_numpy") else np.asarray(y_true).reshape(-1)
+
         # 預測
-        y_pred = model.predict(X)
+        y_pred = model.predict(X_eval)
 
         # ====== 分類報告與基本指標（靜音 UndefinedMetricWarning） ======
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=UndefinedMetricWarning)
-            acc = accuracy_score(y_true, y_pred)
+            acc = accuracy_score(y_true_np, y_pred)
             if self.task == "binary":
-                f1 = f1_score(y_true, y_pred, average="binary", zero_division=0)
-                prec = precision_score(y_true, y_pred, average="binary", zero_division=0)
-                rec = recall_score(y_true, y_pred, average="binary", zero_division=0)
-                report = classification_report(y_true, y_pred, digits=4, zero_division=0)
+                f1 = f1_score(y_true_np, y_pred, average="binary", zero_division=0)
+                prec = precision_score(y_true_np, y_pred, average="binary", zero_division=0)
+                rec = recall_score(y_true_np, y_pred, average="binary", zero_division=0)
+                report = classification_report(y_true_np, y_pred, digits=4, zero_division=0)
             else:
-                f1 = f1_score(y_true, y_pred, average="macro", zero_division=0)
-                prec = precision_score(y_true, y_pred, average="macro", zero_division=0)
-                rec = recall_score(y_true, y_pred, average="macro", zero_division=0)
-                report = classification_report(y_true, y_pred, digits=4, zero_division=0)
+                f1 = f1_score(y_true_np, y_pred, average="macro", zero_division=0)
+                prec = precision_score(y_true_np, y_pred, average="macro", zero_division=0)
+                rec = recall_score(y_true_np, y_pred, average="macro", zero_division=0)
+                report = classification_report(y_true_np, y_pred, digits=4, zero_division=0)
 
         # ====== AUC（binary / multiclass OVR） ======
         auc = np.nan
         try:
             if hasattr(model, "predict_proba"):
-                proba = model.predict_proba(X)
+                proba = model.predict_proba(X_eval)
                 if self.task == "binary":
                     # 取正類索引為 1；若 classes_ 不含 1，用最後一類
                     pos_idx = 1
                     if hasattr(model, "classes_"):
                         cls = list(model.classes_)
                         pos_idx = cls.index(1) if 1 in cls else (len(cls) - 1)
-                    auc = roc_auc_score(y_true, proba[:, pos_idx])
+                    auc = roc_auc_score(y_true_np, proba[:, pos_idx])
                 else:
-                    auc = roc_auc_score(y_true, proba, multi_class="ovr")
+                    auc = roc_auc_score(y_true_np, proba, multi_class="ovr")
         except Exception:
             pass  # 保留 auc=nan
 
@@ -80,7 +83,7 @@ class Evaluator:
         print("📋 分類報告：")
         print(report)
 
-        cm = confusion_matrix(y_true, y_pred)
+        cm = confusion_matrix(y_true_np, y_pred)
         print("📝 混淆矩陣：")
         print(cm)
 

--- a/training_pipeline/model_builder.py
+++ b/training_pipeline/model_builder.py
@@ -11,6 +11,7 @@ from typing import Dict, Optional
 
 import warnings
 import numpy as np
+import pandas as pd
 import optuna
 from optuna.pruners import MedianPruner
 
@@ -31,6 +32,12 @@ except Exception:  # pragma: no cover - cupy may not be installed
     cp = None  # type: ignore[assignment]
 
     CUPY_AVAILABLE = False
+
+def _to_numpy(X, y):
+    X_np = X.to_numpy() if hasattr(X, 'to_numpy') else np.asarray(X)
+    y_np = y.to_numpy().reshape(-1) if hasattr(y, 'to_numpy') else np.asarray(y).reshape(-1)
+    return X_np, y_np
+
 
 
 class ModelBuilder:
@@ -104,8 +111,8 @@ class ModelBuilder:
         """
         best_params: Dict[str, dict] = {}
         rng = self.config.get("RANDOM_STATE", 42)
-        X = np.asarray(X)
-        y = np.asarray(y)
+        X, y = _to_numpy(X, y)
+        y = y.astype("int32")
         cv = StratifiedKFold(n_splits=5, shuffle=True, random_state=rng)
         pruner = self.pruner
 

--- a/utils_labels.py
+++ b/utils_labels.py
@@ -1,0 +1,30 @@
+import json
+import os
+import numpy as np
+import pandas as pd
+
+CRLEVEL_MAP = {
+    "unknown": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+    "critical": 4,
+}
+INV_CRLEVEL_MAP = {v: k for k, v in CRLEVEL_MAP.items()}
+
+def encode_crlevel_series(y: pd.Series) -> pd.Series:
+    """將字串 crlevel 統一映射為 0..4，回傳 int32 Series。"""
+    if y.dtype == object:
+        y2 = y.str.lower().map(CRLEVEL_MAP)
+        if y2.isna().any():
+            bad = sorted(y[y2.isna()].unique().tolist())
+            raise ValueError(f"[crlevel 編碼] 出現未知標籤：{bad}")
+        return y2.astype("int32")
+    return y.astype("int32")
+
+def save_label_mapping(out_dir: str):
+    os.makedirs(out_dir, exist_ok=True)
+    path = os.path.join(out_dir, "label_mapping.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump({"crlevel_map": CRLEVEL_MAP}, f, ensure_ascii=False, indent=2)
+    return path


### PR DESCRIPTION
## Summary
- add utility for crlevel label encoding and mapping export
- encode and reset labels/splits before training; ensure ensemble uses at least two models
- unify numpy data flow across model building, evaluation, and optuna ensemble to avoid indexing and warning issues

## Testing
- `python3 -m pytest -q Dflare_Fortinet/tests` *(fails: No module named pytest)*
- `pip install pytest` *(fails: Could not find a version that satisfies the requirement pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6f199cd48320824bff66b0d104ef

## Sourcery 总结

标准化数据预处理，具体做法是在评估、模型构建和集成例程中将 pandas 输入转换为 numpy 数组，并将标签转换为 int32 类型；在集成优化中强制至少有两个模型；添加 CR 级别标签编码工具并支持映射导出；以及在数据分割后重置索引。

新功能：
- 添加将 CR 级别字符串标签编码为数字代码并导出标签映射的工具

错误修复：
- 通过将默认的 min_models 从 1 提高到 2，强制 Optuna 和投票集成搜索中至少包含两个模型

增强：
- 在评估器、模型构建器和集成评分器中将 pandas DataFrame/Series 输入转换为 numpy 数组，以避免索引问题和警告
- 重置特征和标签在训练集和验证集分割后的索引
- 在默认管道集成设置中包含 MIN_MODELS=2
- 将所有训练例程的标签数据类型标准化为 int32

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize data preprocessing by converting pandas inputs to numpy arrays and casting labels to int32 across evaluation, model building, and ensemble routines; enforce a minimum of two models in ensemble optimizations; add CR-level label encoding utility with mapping export; and reset indices after data splitting.

New Features:
- Add utilities to encode CR-level string labels into numeric codes and export the label mapping

Bug Fixes:
- Enforce at least two models in Optuna and voting ensemble searches by raising the default min_models from 1 to 2

Enhancements:
- Convert pandas DataFrame/Series inputs to numpy arrays in evaluator, model builder, and ensemble scorer to avoid indexing issues and warnings
- Reset indices on training and validation splits for both features and labels
- Include MIN_MODELS=2 in default pipeline ensemble settings
- Standardize label datatype to int32 for all training routines

</details>