### PR TITLE
Remove LightGBM safe parameter adjustments

### DIFF
--- a/training_pipeline/combo_optimizer.py
+++ b/training_pipeline/combo_optimizer.py
@@ -31,7 +31,7 @@ except Exception:
     UndefinedMetricWarning = Warning  # 兼容舊版
 
 
-# ---------------- 工具：CPU 安全化（避免 Stacking/Voting 重新訓練 clone 時觸發單卡 GPU 衝突） ----------------
+# ---------------- 工具：CPU 版（避免 Stacking/Voting 重新訓練 clone 時觸發單卡 GPU 衝突） ----------------
 def _set_if_has(est, **pairs):
     """若 est 支援該參數，才設定；不丟例外。"""
     try:
@@ -55,15 +55,6 @@ def _as_cpu_estimator(est):
     # CatBoost
     if "catboost" in name:
         _set_if_has(e, task_type="CPU", devices="", verbose=False)
-
-    # LightGBM sklearn API
-    if "lgbm" in name or "lightgbm" in name:
-        params = e.get_params()
-        if "device_type" in params:
-            _set_if_has(e, device_type="cpu")
-        elif "device" in params:
-            _set_if_has(e, device="cpu")
-        _set_if_has(e, n_jobs=1, verbosity=-1, force_col_wise=True, deterministic=True)
 
     # XGBoost sklearn API
     if "xgb" in name or "xgboost" in name:
@@ -196,13 +187,13 @@ class ComboOptimizer:
         voting_mode = str(self.ens.get("VOTING", "soft")).lower()
         stack_cv = int(self.ens.get("STACK_CV", 5))
 
-        # 建立 CPU 安全化後的基模型清單（避免 clone 時再開 GPU）
-        safe_estimators = [(name, _as_cpu_estimator(est)) for name, est in self.base_estimators]
+        # 建立 CPU 版的基模型清單（避免 clone 時再開 GPU）
+        cpu_estimators = [(name, _as_cpu_estimator(est)) for name, est in self.base_estimators]
 
         # ============ 分支一：Voting + Optuna ============ 
         if self.use_optuna and voting_mode in ("soft", "hard"):
             try:
-                final_model, metrics, composition = self._optuna_voting_search(safe_estimators, voting_mode)
+                final_model, metrics, composition = self._optuna_voting_search(cpu_estimators, voting_mode)
                 self._save_ensemble(final_model)
                 self._write_final_txt(kind="voting", metrics=metrics, composition=composition)
                 kind_desc = f"OptunaEnsembler（mode='{self.ens.get('MODE', 'free')}'）"
@@ -214,10 +205,10 @@ class ComboOptimizer:
         if voting_mode in ("soft", "hard"):
             if self.ens.get("SEARCH", "none") == "voting_subsets":
                 print("🔍 集成搜尋：使用固定子集枚舉搜尋（Top-K）。")
-                results = self._search_voting_subsets(safe_estimators, voting_mode)
+                results = self._search_voting_subsets(cpu_estimators, voting_mode)
                 # 以最佳名稱組合重訓並保存（避免把 estimator 物件寫入 JSON）
                 best_names = results["best_names"]
-                pool = {n: e for n, e in safe_estimators}
+                pool = {n: e for n, e in cpu_estimators}
                 best_ests = [(n, clone(pool[n])) for n in best_names]
 
                 final_model = self._fit_voting(best_ests, voting_mode)
@@ -239,17 +230,17 @@ class ComboOptimizer:
                 kind_desc = f"VotingClassifier（voting='{voting_mode}'）"
                 return self._finalize(kind_desc, final_model, metrics, composition)
             else:
-                final_model = self._fit_voting(safe_estimators, voting_mode)
+                final_model = self._fit_voting(cpu_estimators, voting_mode)
                 self._save_ensemble(final_model)
-                metrics, composition = self._eval_and_compose(final_model, kind="voting", estimators=safe_estimators)
+                metrics, composition = self._eval_and_compose(final_model, kind="voting", estimators=cpu_estimators)
                 self._write_final_txt(kind="voting", metrics=metrics, composition=composition)
                 kind_desc = f"VotingClassifier（voting='{voting_mode}'）"
                 return self._finalize(kind_desc, final_model, metrics, composition)
         else:
             # Stacking
-            final_model = self._fit_stacking(safe_estimators, cv=stack_cv)
+            final_model = self._fit_stacking(cpu_estimators, cv=stack_cv)
             self._save_ensemble(final_model)
-            metrics, composition = self._eval_and_compose(final_model, kind="stacking", estimators=safe_estimators)
+            metrics, composition = self._eval_and_compose(final_model, kind="stacking", estimators=cpu_estimators)
             self._write_final_txt(kind="stacking", metrics=metrics, composition=composition)
             kind_desc = f"StackingClassifier（cv={stack_cv}）"
             return self._finalize(kind_desc, final_model, metrics, composition)

--- a/training_pipeline/trainer.py
+++ b/training_pipeline/trainer.py
@@ -5,7 +5,6 @@ import numpy as np
 import warnings
 from typing import Dict, Any, Tuple
 
-from sklearn.base import clone
 from sklearn.exceptions import ConvergenceWarning
 
 # 靜音部分無關緊要的警告，保留你原有輸出風格
@@ -16,7 +15,6 @@ class Trainer:
     """
     訓練器：逐一訓練 models dict 內的模型。
     - 保留原有印出格式與語氣。
-    - 對 LightGBM 加入多層級「安全參數」與資料清理，避免 left_count==0 的 Fatal。
     - 全程不改你的互動方式與 CLI。
     """
 
@@ -35,36 +33,8 @@ class Trainer:
     def _fit_one(self, name: str, est, X, y):
         """
         - 統一先做資料健檢與清理（對所有模型一致）。
-        - 對 LGBM 額外做多層級 fallback。
         """
         X_pre, y_clean = self._sanitize_xy(X, y)
-
-        # LightGBM：套用安全訓練流程
-        if self._is_lgbm(est):
-            # level 1
-            safe_est = self._make_lgb_safe(est, level=1)
-            print("🛡️  [LGB] 使用 LightGBM 安全參數訓練（避免空子節點 Fatal）")
-            try:
-                return self._fit_silent(safe_est, X_pre, y_clean)
-            except Exception as e1:
-                print(f"\n⚠️  [LGB] 安全參數仍失敗，升級保守度後再試。錯誤：{e1}\n")
-
-            # level 2
-            safer_est = self._make_lgb_safe(est, level=2)
-            try:
-                return self._fit_silent(safer_est, X_pre, y_clean)
-            except Exception as e2:
-                print(f"\n⚠️  [LGB] 第二層保守參數仍失敗，嘗試最嚴格模式（row-wise + 更小 max_bin）。錯誤：{e2}\n")
-
-            # level 3（最嚴格）
-            safest_est = self._make_lgb_safe(est, level=3)
-            try:
-                return self._fit_silent(safest_est, X_pre, y_clean)
-            except Exception as e3:
-                # 到這層仍失敗，回拋例外，讓上層顯示一致的「發生未預期錯誤」
-                raise e3
-
-        # 其他模型：原樣訓練
         return self._fit_silent(est, X_pre, y_clean)
 
     def _fit_silent(self, est, X, y):
@@ -72,121 +42,6 @@ class Trainer:
         est.fit(X, y)
         return est
 
-    # ===================== LightGBM Utilities =====================
-    def _is_lgbm(self, est) -> bool:
-        cls = est.__class__.__name__.lower()
-        return ("lgbm" in cls) or ("lightgbm" in cls)
-
-    def _make_lgb_safe(self, est, level: int = 1):
-        """
-        多層級防呆設定，僅在參數存在時才設定，不會破壞你原本傳入參數。
-        目標：避免「best_split_info.left_count == 0」的 Fatal。
-        """
-        m = clone(est)
-        params = m.get_params()
-
-        def set_if_has(**pairs):
-            exist = {k: v for k, v in pairs.items() if k in params}
-            if exist:
-                m.set_params(**exist)
-
-        # 通用安全項（各層共享）
-        # - CPU + 決定式 + 行為收斂
-        set_if_has(n_jobs=1)
-        if "device_type" in params:
-            set_if_has(device_type="cpu")
-        elif "device" in params:
-            set_if_has(device="cpu")
-
-        # LightGBM sklearn API 的常見鍵
-        for k in ("verbosity", "force_col_wise", "deterministic", "zero_as_missing",
-                  "feature_pre_filter", "enable_bundle", "max_bin", "min_data_in_bin",
-                  "min_data_in_leaf", "min_sum_hessian_in_leaf", "min_gain_to_split",
-                  "num_leaves", "bagging_freq", "bagging_fraction",
-                  "feature_fraction", "lambda_l1", "lambda_l2", "max_depth"):
-            if k not in params:
-                params[k] = None  # 讓 set_if_has 可以辨識
-
-        # 針對類別不平衡（binary 才生效；multiclass 忽略）
-        if "is_unbalance" in params:
-            set_if_has(is_unbalance=True)
-
-        # Level 1：溫和
-        if level == 1:
-            set_if_has(
-                verbosity=-1,
-                force_col_wise=True,            # column-wise 通常較穩
-                deterministic=True,
-                zero_as_missing=True,
-                feature_pre_filter=False,       # 關閉預過濾，避免早期無效分裂
-                enable_bundle=False,            # 關閉特徵打包
-                max_bin=127,                    # 預設 255，降低一半
-                min_data_in_bin=5,              # 每個 bin 至少樣本數
-                min_data_in_leaf=50,            # 葉節點最少樣本數
-                min_sum_hessian_in_leaf=1e-3,   # 避免 hessian 太小
-                min_gain_to_split=0.0,
-                num_leaves=31,
-                bagging_freq=0,
-                bagging_fraction=1.0,
-                feature_fraction=1.0,
-                lambda_l1=0.0,
-                lambda_l2=0.0,
-                max_depth=-1,
-            )
-            return m
-
-        # Level 2：保守
-        if level == 2:
-            set_if_has(
-                verbosity=-1,
-                force_col_wise=True,
-                deterministic=True,
-                zero_as_missing=True,
-                feature_pre_filter=False,
-                enable_bundle=False,
-                max_bin=63,                     # 再縮小分箱
-                min_data_in_bin=15,
-                min_data_in_leaf=200,
-                min_sum_hessian_in_leaf=1e-2,   # 加強 hessian 下限
-                min_gain_to_split=1e-8,
-                num_leaves=15,
-                bagging_freq=0,
-                bagging_fraction=1.0,
-                feature_fraction=0.8,           # 略降特徵比例
-                lambda_l1=1e-3,
-                lambda_l2=1e-2,
-                max_depth=8,
-            )
-            return m
-
-        # Level 3：最嚴格（且切換 row-wise 算法）
-        if level == 3:
-            # 注意：有些版本 key 為 force_row_wise，有些沒有；set_if_has 會自動忽略不存在的鍵。
-            if "force_row_wise" in params:
-                m.set_params(force_row_wise=True)
-
-            set_if_has(
-                verbosity=-1,
-                deterministic=True,
-                zero_as_missing=True,
-                feature_pre_filter=False,
-                enable_bundle=False,
-                max_bin=31,                     # 最小化分箱數，降低「空子節點」機率
-                min_data_in_bin=30,
-                min_data_in_leaf=1000,          # 葉節點更大，保證雙側有人
-                min_sum_hessian_in_leaf=5e-2,   # 明顯提高 hessian 下限
-                min_gain_to_split=0.0,
-                num_leaves=7,
-                bagging_freq=0,
-                bagging_fraction=1.0,
-                feature_fraction=0.6,
-                lambda_l1=1e-2,
-                lambda_l2=1e-1,
-                max_depth=6,
-            )
-            return m
-
-        return m
 
     # ===================== Data Sanitation =====================
     def _sanitize_xy(self, X, y) -> Tuple[np.ndarray, np.ndarray]:


### PR DESCRIPTION
## Summary
- strip LightGBM-specific safety logic from Trainer and DynamicSoftVoter
- drop LightGBM fallback defaults in ModelBuilder and only fix device key
- clean ensemble utilities to avoid forcing LightGBM CPU settings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae7c69e6a48320950e44acce8184c0