### PR TITLE
Disable ensemble subset search by default

### DIFF
--- a/training_pipeline/combo_optimizer.py
+++ b/training_pipeline/combo_optimizer.py
@@ -160,7 +160,7 @@ class ComboOptimizer:
         ens.setdefault("VOTING", "soft")
         ens.setdefault("THRESHOLD", 0.5)
         # Voting 搜尋參數
-        ens.setdefault("SEARCH", "voting_subsets")   # "none" / "voting_subsets"
+        ens.setdefault("SEARCH", "none")   # "none" / "voting_subsets"
         ens.setdefault("SEARCH_MAX_SUBSET", 4)       # 子集最大模型數
         ens.setdefault("SEARCH_TOPK", 3)             # 取 Top-K
         # Optuna 搜尋回合（僅用於 ensemble）

--- a/training_pipeline/config.py
+++ b/training_pipeline/config.py
@@ -45,7 +45,8 @@ CONFIG_BINARY = {
     "ENSEMBLE_SETTINGS": {
         "STACK_CV": 5,
         "VOTING": "soft",
-        "THRESHOLD": 0.33
+        "THRESHOLD": 0.33,
+        "SEARCH": "none"
     }
 }
 
@@ -97,6 +98,7 @@ CONFIG_MULTICLASS = {
     "ENSEMBLE_SETTINGS": {
         "STACK_CV": 5,
         "VOTING": "soft",
-        "THRESHOLD": 0.33
+        "THRESHOLD": 0.33,
+        "SEARCH": "none"
     }
 }

--- a/training_pipeline/pipeline_main.py
+++ b/training_pipeline/pipeline_main.py
@@ -63,7 +63,7 @@ class TrainingPipeline:
         self.config.setdefault("RANDOM_STATE", 42)
         self.config.setdefault("ENSEMBLE_SETTINGS", {
             "STACK_CV": 5, "VOTING": "soft", "THRESHOLD": 0.5,
-            "SEARCH": "voting_subsets", "SEARCH_MAX_SUBSET": 4, "SEARCH_TOPK": 3, "MIN_MODELS": 2
+            "SEARCH": "none", "SEARCH_MAX_SUBSET": 4, "SEARCH_TOPK": 3, "MIN_MODELS": 2
         })
         self.config.setdefault("OUTPUT_DIR", "./artifacts")
         self.config.setdefault("SAVE_BASE_MODELS", False)


### PR DESCRIPTION
## Summary
- Default ensemble settings now skip subset enumeration search
- Avoid ComboOptimizer enabling `voting_subsets` search unless explicitly requested

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2e9bfd8c48320a916d7e484e8f1b9

## Sourcery 总结

默认禁用集成子集搜索，方法是在配置和优化器中添加一个默认为 "none" 的新 `SEARCH` 设置，从而阻止 `voting_subsets` 枚举，除非明确启用。

增强功能：
- 在默认集成设置中引入一个 "SEARCH" 参数，并在 config.py 中将其设置为 "none"。
- 更新 ComboOptimizer，将 `SEARCH` 的默认值设为 "none"，而非 "voting_subsets"。
- 调整 pipeline_main 的默认设置，通过将 `SEARCH` 设置为 "none" 来禁用投票子集搜索。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Disable ensemble subset search by default by adding a new SEARCH setting defaulted to "none" across the configuration and optimizer, preventing voting_subsets enumeration unless explicitly enabled.

Enhancements:
- Introduce a "SEARCH" parameter in default ensemble settings and set it to "none" in config.py.
- Update ComboOptimizer to default SEARCH to "none" instead of "voting_subsets".
- Adjust pipeline_main defaults to disable voting subset search by setting SEARCH to "none".

</details>