### PR TITLE
Disable ensemble subset search by default

### DIFF
--- a/training_pipeline/combo_optimizer.py
+++ b/training_pipeline/combo_optimizer.py
@@ -160,7 +160,7 @@ class ComboOptimizer:
         ens.setdefault("VOTING", "soft")
         ens.setdefault("THRESHOLD", 0.5)
         # Voting 搜尋參數
-        ens.setdefault("SEARCH", "voting_subsets")   # "none" / "voting_subsets"
+        ens.setdefault("SEARCH", "none")   # "none" / "voting_subsets"
         ens.setdefault("SEARCH_MAX_SUBSET", 4)       # 子集最大模型數
         ens.setdefault("SEARCH_TOPK", 3)             # 取 Top-K
         # Optuna 搜尋回合（僅用於 ensemble）

--- a/training_pipeline/config.py
+++ b/training_pipeline/config.py
@@ -45,7 +45,8 @@ CONFIG_BINARY = {
     "ENSEMBLE_SETTINGS": {
         "STACK_CV": 5,
         "VOTING": "soft",
-        "THRESHOLD": 0.33
+        "THRESHOLD": 0.33,
+        "SEARCH": "none"
     }
 }
 
@@ -97,6 +98,7 @@ CONFIG_MULTICLASS = {
     "ENSEMBLE_SETTINGS": {
         "STACK_CV": 5,
         "VOTING": "soft",
-        "THRESHOLD": 0.33
+        "THRESHOLD": 0.33,
+        "SEARCH": "none"
     }
 }

--- a/training_pipeline/pipeline_main.py
+++ b/training_pipeline/pipeline_main.py
@@ -63,7 +63,7 @@ class TrainingPipeline:
         self.config.setdefault("RANDOM_STATE", 42)
         self.config.setdefault("ENSEMBLE_SETTINGS", {
             "STACK_CV": 5, "VOTING": "soft", "THRESHOLD": 0.5,
-            "SEARCH": "voting_subsets", "SEARCH_MAX_SUBSET": 4, "SEARCH_TOPK": 3, "MIN_MODELS": 2
+            "SEARCH": "none", "SEARCH_MAX_SUBSET": 4, "SEARCH_TOPK": 3, "MIN_MODELS": 2
         })
         self.config.setdefault("OUTPUT_DIR", "./artifacts")
         self.config.setdefault("SAVE_BASE_MODELS", False)

--- a/training_pipeline/trainer.py
+++ b/training_pipeline/trainer.py
@@ -47,10 +47,10 @@ class Trainer:
         try:
             est.fit(X, y)
             return est
-        except LightGBMError as e:
-            msg = str(e)
-            if "best_split_info.left_count" in msg and hasattr(est, "set_params"):
+        except LightGBMError:
+            if hasattr(est, "set_params"):
                 try:
+                    print("⚠️  LightGBM GPU 失敗，改用 CPU 重新訓練。")
                     est.set_params(device_type="cpu")
                     est.fit(X, y)
                     return est

--- a/ui_pages/gpu_etl_ui.py
+++ b/ui_pages/gpu_etl_ui.py
@@ -47,7 +47,8 @@ def app() -> None:
         thread.start()
         pct = 0
         while thread.is_alive():
-            pct = (pct + 5) % 100
+            if pct < 95:
+                pct += 5
             progress.progress(pct)
             status.text(f"ETL in progress... {pct}%")
             time.sleep(0.1)

--- a/ui_pages/inference_ui.py
+++ b/ui_pages/inference_ui.py
@@ -55,7 +55,8 @@ def app() -> None:
         thread.start()
         pct = 0
         while thread.is_alive():
-            pct = (pct + 5) % 100
+            if pct < 95:
+                pct += 5
             progress.progress(pct)
             status.text(f"Inference in progress... {pct}%")
             time.sleep(0.1)

--- a/ui_pages/training_ui.py
+++ b/ui_pages/training_ui.py
@@ -90,7 +90,8 @@ def app() -> None:
         pct = 0
         log_text = ""
         while thread.is_alive():
-            pct = (pct + 5) % 100
+            if pct < 95:
+                pct += 5
             progress.progress(pct)
             status.text(f"Training in progress... {pct}%")
             while not log_queue.empty():


### PR DESCRIPTION
## Summary
- Default ensemble settings now skip subset enumeration search
- Avoid ComboOptimizer enabling `voting_subsets` search unless explicitly requested
- Prevent UI progress bars from bouncing by capping forward increments
- Fall back to CPU when LightGBM GPU training fails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2e9bfd8c48320a916d7e484e8f1b9

## Sourcery 总结

禁用集成中默认的投票子集搜索，添加 UI 进度条上限以避免闪烁，并通过在 LightGBM GPU 错误时回退到 CPU 来提高训练的鲁棒性

错误修复：
- 当 LightGBM GPU 训练失败时，回退到 CPU 并显示警告消息

增强功能：
- 在配置和 ComboOptimizer 中默认禁用集成子集搜索
- 通过将前进增量上限设置为 95% 来防止 UI 进度条跳动

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Disable the default voting subsets search in ensembles, add a UI progress bar cap to avoid flickering, and improve training robustness by falling back to CPU on LightGBM GPU errors

Bug Fixes:
- Fall back to CPU with a warning message when LightGBM GPU training fails

Enhancements:
- Disable ensemble subset search by default across configuration and ComboOptimizer
- Prevent UI progress bars from bouncing by capping forward increments at 95%

</details>