### PR TITLE
Set LightGBM seed and leaf size

### DIFF
--- a/training_pipeline/config.py
+++ b/training_pipeline/config.py
@@ -7,7 +7,7 @@ CONFIG_BINARY = {
         "proto_port", "sub_action", "svc_action"
     ],
     "VALID_SIZE": 0.2,
-    "RANDOM_STATE": 42,
+    "RANDOM_STATE": 100,
     "MODEL_PARAMS": {
         "XGB": {
             "n_estimators": 114,
@@ -24,6 +24,7 @@ CONFIG_BINARY = {
             "max_depth": 12,
             "learning_rate": 0.29348213117409244,
             "num_leaves": 108,
+            "min_child_samples": 1,
             "device": "gpu"
         },
         "CAT": {
@@ -59,7 +60,7 @@ CONFIG_MULTICLASS = {
         "proto_port", "sub_action", "svc_action"
     ],
     "VALID_SIZE": 0.2,
-    "RANDOM_STATE": 42,
+    "RANDOM_STATE": 100,
     "MODEL_PARAMS": {
         "XGB": {
             "n_estimators": 82,
@@ -77,6 +78,7 @@ CONFIG_MULTICLASS = {
             "max_depth": 4,
             "learning_rate": 0.07476200160360733,
             "num_leaves": 79,
+            "min_child_samples": 1,
             "device": "gpu"
         },
         "CAT": {

--- a/training_pipeline/model_builder.py
+++ b/training_pipeline/model_builder.py
@@ -394,6 +394,8 @@ class ModelBuilder:
         p = self._fix_lgb_device(base, y, task)
         if tuned and "LGB" in tuned:
             p.update(tuned["LGB"])
+        p.setdefault("random_state", self.config.get("RANDOM_STATE", 42))
+        p.setdefault("verbose", 0)
         p.update(task_args["LGB"])
         return p
 


### PR DESCRIPTION
## Summary
- Set pipeline RNG seed to 100 and propagate to LightGBM
- Allow deeper LightGBM trees with `min_child_samples=1`
- Default LightGBM verbosity to 0 for clearer warnings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2f6524c688320ab1234331d3b16ab