### PR TITLE
Set LightGBM seed and leaf size

### DIFF
--- a/training_pipeline/config.py
+++ b/training_pipeline/config.py
@@ -7,7 +7,7 @@ CONFIG_BINARY = {
         "proto_port", "sub_action", "svc_action"
     ],
     "VALID_SIZE": 0.2,
-    "RANDOM_STATE": 42,
+    "RANDOM_STATE": 100,
     "MODEL_PARAMS": {
         "XGB": {
             "n_estimators": 114,
@@ -24,6 +24,7 @@ CONFIG_BINARY = {
             "max_depth": 12,
             "learning_rate": 0.29348213117409244,
             "num_leaves": 108,
+            "min_child_samples": 1,
             "device": "gpu"
         },
         "CAT": {
@@ -59,40 +60,39 @@ CONFIG_MULTICLASS = {
         "proto_port", "sub_action", "svc_action"
     ],
     "VALID_SIZE": 0.2,
-    "RANDOM_STATE": 42,
+    "RANDOM_STATE": 100,
     "MODEL_PARAMS": {
         "XGB": {
-            "n_estimators": 82,
-            "max_depth": 6,
-            "learning_rate": 0.028066024152840267,
-            "subsample": 0.6929780665557963,
-            "colsample_bytree": 0.7019399941296385,
+            "n_estimators": 189,
+            "max_depth": 8,
+            "learning_rate": 0.1898717379219999,
+            "subsample": 0.6875100692343238,
+            "colsample_bytree": 0.5147427892922118,
             "tree_method": "hist",
-            "device": "cuda",
+            "device": "cpu",
             "use_label_encoder": False,
             "eval_metric": "mlogloss"
         },
         "LGB": {
-            "n_estimators": 139,
-            "max_depth": 4,
-            "learning_rate": 0.07476200160360733,
-            "num_leaves": 79,
-            "device": "gpu"
+            "n_estimators": 360,
+            "max_depth": -1,
+            "learning_rate": 0.06919566270449405,
+            "num_leaves": 31
         },
         "CAT": {
-            "depth": 4,
-            "learning_rate": 0.08271529761904835,
-            "iterations": 82,
+            "depth": 10,
+            "learning_rate": 0.0768152029814235,
+            "iterations": 249,
             "task_type": "GPU",
             "devices": "0"
         },
         "RF": {
-            "n_estimators": 163,
-            "max_depth": 6
+            "n_estimators": 167,
+            "max_depth": 10
         },
         "ET": {
-            "n_estimators": 161,
-            "max_depth": 7
+            "n_estimators": 227,
+            "max_depth": 12
         }
     },
     "ENSEMBLE_SETTINGS": {

--- a/training_pipeline/model_builder.py
+++ b/training_pipeline/model_builder.py
@@ -394,6 +394,10 @@ class ModelBuilder:
         p = self._fix_lgb_device(base, y, task)
         if tuned and "LGB" in tuned:
             p.update(tuned["LGB"])
+        p.setdefault("random_state", self.config.get("RANDOM_STATE", 42))
+        # Silence LightGBM warnings like "No further splits with positive gain"
+        p.pop("verbose", None)
+        p.setdefault("verbosity", -1)
         p.update(task_args["LGB"])
         return p
 


### PR DESCRIPTION
## Summary
- Set pipeline RNG seed to 100 and propagate to LightGBM
- Allow deeper LightGBM trees with `min_child_samples=1`
- Default LightGBM verbosity to -1 to silence split warnings
- Restore tuned multiclass model parameters for XGB, LGB, CAT, RF, and ET

## Testing
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2f6524c688320ab1234331d3b16ab