### PR TITLE
Set LightGBM seed and leaf size

### DIFF
--- a/training_pipeline/config.py
+++ b/training_pipeline/config.py
@@ -7,7 +7,7 @@ CONFIG_BINARY = {
         "proto_port", "sub_action", "svc_action"
     ],
     "VALID_SIZE": 0.2,
-    "RANDOM_STATE": 42,
+    "RANDOM_STATE": 100,
     "MODEL_PARAMS": {
         "XGB": {
             "n_estimators": 114,
@@ -17,13 +17,13 @@ CONFIG_BINARY = {
             "colsample_bytree": 0.6125623581444746,
             "tree_method": "hist",
             "device": "cuda",
-            "use_label_encoder": False,
             "eval_metric": "logloss"
         },
         "LGB": {
             "max_depth": 12,
             "learning_rate": 0.29348213117409244,
             "num_leaves": 108,
+            "min_child_samples": 1,
             "device": "gpu"
         },
         "CAT": {
@@ -59,40 +59,38 @@ CONFIG_MULTICLASS = {
         "proto_port", "sub_action", "svc_action"
     ],
     "VALID_SIZE": 0.2,
-    "RANDOM_STATE": 42,
+    "RANDOM_STATE": 100,
     "MODEL_PARAMS": {
         "XGB": {
-            "n_estimators": 82,
-            "max_depth": 6,
-            "learning_rate": 0.028066024152840267,
-            "subsample": 0.6929780665557963,
-            "colsample_bytree": 0.7019399941296385,
+            "n_estimators": 189,
+            "max_depth": 8,
+            "learning_rate": 0.1898717379219999,
+            "subsample": 0.6875100692343238,
+            "colsample_bytree": 0.5147427892922118,
             "tree_method": "hist",
-            "device": "cuda",
-            "use_label_encoder": False,
+            "device": "cpu",
             "eval_metric": "mlogloss"
         },
         "LGB": {
-            "n_estimators": 139,
-            "max_depth": 4,
-            "learning_rate": 0.07476200160360733,
-            "num_leaves": 79,
-            "device": "gpu"
+            "n_estimators": 360,
+            "max_depth": -1,
+            "learning_rate": 0.06919566270449405,
+            "num_leaves": 31
         },
         "CAT": {
-            "depth": 4,
-            "learning_rate": 0.08271529761904835,
-            "iterations": 82,
+            "depth": 10,
+            "learning_rate": 0.0768152029814235,
+            "iterations": 249,
             "task_type": "GPU",
             "devices": "0"
         },
         "RF": {
-            "n_estimators": 163,
-            "max_depth": 6
+            "n_estimators": 167,
+            "max_depth": 10
         },
         "ET": {
-            "n_estimators": 161,
-            "max_depth": 7
+            "n_estimators": 227,
+            "max_depth": 12
         }
     },
     "ENSEMBLE_SETTINGS": {

--- a/training_pipeline/model_builder.py
+++ b/training_pipeline/model_builder.py
@@ -394,6 +394,10 @@ class ModelBuilder:
         p = self._fix_lgb_device(base, y, task)
         if tuned and "LGB" in tuned:
             p.update(tuned["LGB"])
+        p.setdefault("random_state", self.config.get("RANDOM_STATE", 42))
+        # Silence LightGBM warnings like "No further splits with positive gain"
+        p.pop("verbose", None)
+        p.setdefault("verbosity", -1)
         p.update(task_args["LGB"])
         return p
 

--- a/training_pipeline/pipeline_main.py
+++ b/training_pipeline/pipeline_main.py
@@ -112,7 +112,7 @@ class TrainingPipeline:
 
         defaults = {
             "XGB": ["n_estimators", "max_depth", "learning_rate", "subsample", "colsample_bytree",
-                    "tree_method", "device", "use_label_encoder", "eval_metric"],
+                    "tree_method", "device", "eval_metric"],
             "LGB": ["n_estimators", "max_depth", "learning_rate", "num_leaves", "device_type"],
             "CAT": ["iterations", "depth", "learning_rate", "task_type", "devices"],
             "RF":  ["n_estimators", "max_depth"],


### PR DESCRIPTION
## Summary
- Set pipeline RNG seed to 100 and propagate to LightGBM
- Allow deeper LightGBM trees with `min_child_samples=1`
- Default LightGBM verbosity to -1 to silence split warnings
- Restore tuned multiclass model parameters for XGB, LGB, CAT, RF, and ET
- Drop deprecated `use_label_encoder` from XGBoost configs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2f6524c688320ab1234331d3b16ab

## Sourcery 总结

更新模型配置，使用固定的RNG种子和在所有学习器中优化的超参数，移除已弃用的XGBoost选项，并通过允许更深的分裂和抑制警告来改进LightGBM行为。

增强功能：
- 将管道随机种子从 42 更新为 100，并将其传播到 LightGBM
- 恢复针对 XGB、LGB、CAT、RF 和 ET 模型的已调优多分类超参数
- 移除已弃用的 XGBoost `use_label_encoder` 配置
- 通过设置 `min_child_samples=1` 允许 LightGBM 树更深
- 通过删除 `verbose` 并将 `verbosity=-1` 默认为来抑制 LightGBM 警告

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update model configuration to use a fixed RNG seed and refined hyperparameters across all learners, remove deprecated XGBoost option, and improve LightGBM behavior by allowing deeper splits and silencing warnings

Enhancements:
- Update pipeline random seed from 42 to 100 and propagate it to LightGBM
- Restore tuned multiclass hyperparameters for XGB, LGB, CAT, RF, and ET models
- Remove deprecated XGBoost `use_label_encoder` configuration
- Allow deeper LightGBM trees by setting `min_child_samples=1`
- Silence LightGBM warnings by dropping `verbose` and defaulting `verbosity=-1`

</details>