### PR TITLE
Set LightGBM seed and leaf size

### DIFF
--- a/training_pipeline/config.py
+++ b/training_pipeline/config.py
@@ -7,7 +7,7 @@ CONFIG_BINARY = {
         "proto_port", "sub_action", "svc_action"
     ],
     "VALID_SIZE": 0.2,
-    "RANDOM_STATE": 42,
+    "RANDOM_STATE": 100,
     "MODEL_PARAMS": {
         "XGB": {
             "n_estimators": 114,
@@ -16,15 +16,13 @@ CONFIG_BINARY = {
             "subsample": 0.6482232909747706,
             "colsample_bytree": 0.6125623581444746,
             "tree_method": "hist",
-            "device": "cuda",
-            "use_label_encoder": False,
+            "device": "cpu",
             "eval_metric": "logloss"
         },
         "LGB": {
             "max_depth": 12,
             "learning_rate": 0.29348213117409244,
-            "num_leaves": 108,
-            "device": "gpu"
+            "num_leaves": 108
         },
         "CAT": {
             "depth": 6,
@@ -59,40 +57,38 @@ CONFIG_MULTICLASS = {
         "proto_port", "sub_action", "svc_action"
     ],
     "VALID_SIZE": 0.2,
-    "RANDOM_STATE": 42,
+    "RANDOM_STATE": 100,
     "MODEL_PARAMS": {
         "XGB": {
-            "n_estimators": 82,
-            "max_depth": 6,
-            "learning_rate": 0.028066024152840267,
-            "subsample": 0.6929780665557963,
-            "colsample_bytree": 0.7019399941296385,
+            "n_estimators": 189,
+            "max_depth": 8,
+            "learning_rate": 0.1898717379219999,
+            "subsample": 0.6875100692343238,
+            "colsample_bytree": 0.5147427892922118,
             "tree_method": "hist",
-            "device": "cuda",
-            "use_label_encoder": False,
+            "device": "cpu",
             "eval_metric": "mlogloss"
         },
         "LGB": {
-            "n_estimators": 139,
-            "max_depth": 4,
-            "learning_rate": 0.07476200160360733,
-            "num_leaves": 79,
-            "device": "gpu"
+            "n_estimators": 360,
+            "max_depth": -1,
+            "learning_rate": 0.06919566270449405,
+            "num_leaves": 31
         },
         "CAT": {
-            "depth": 4,
-            "learning_rate": 0.08271529761904835,
-            "iterations": 82,
+            "depth": 10,
+            "learning_rate": 0.0768152029814235,
+            "iterations": 249,
             "task_type": "GPU",
             "devices": "0"
         },
         "RF": {
-            "n_estimators": 163,
-            "max_depth": 6
+            "n_estimators": 167,
+            "max_depth": 10
         },
         "ET": {
-            "n_estimators": 161,
-            "max_depth": 7
+            "n_estimators": 227,
+            "max_depth": 12
         }
     },
     "ENSEMBLE_SETTINGS": {

--- a/training_pipeline/config.py
+++ b/training_pipeline/config.py
@@ -22,7 +22,8 @@ CONFIG_BINARY = {
         "LGB": {
             "max_depth": 12,
             "learning_rate": 0.29348213117409244,
-            "num_leaves": 108
+            "num_leaves": 108,
+            "min_child_samples": 1
         },
         "CAT": {
             "depth": 6,
@@ -73,7 +74,8 @@ CONFIG_MULTICLASS = {
             "n_estimators": 360,
             "max_depth": -1,
             "learning_rate": 0.06919566270449405,
-            "num_leaves": 31
+            "num_leaves": 31,
+            "min_child_samples": 1
         },
         "CAT": {
             "depth": 10,

--- a/training_pipeline/model_builder.py
+++ b/training_pipeline/model_builder.py
@@ -395,6 +395,7 @@ class ModelBuilder:
         if tuned and "LGB" in tuned:
             p.update(tuned["LGB"])
         p.setdefault("random_state", self.config.get("RANDOM_STATE", 42))
+        p.setdefault("min_child_samples", 1)
         # Silence LightGBM "No further splits" warnings but keep standard output
         p.pop("verbose", None)
         p.setdefault("verbosity", 0)

--- a/training_pipeline/model_builder.py
+++ b/training_pipeline/model_builder.py
@@ -394,6 +394,10 @@ class ModelBuilder:
         p = self._fix_lgb_device(base, y, task)
         if tuned and "LGB" in tuned:
             p.update(tuned["LGB"])
+        p.setdefault("random_state", self.config.get("RANDOM_STATE", 42))
+        # Silence LightGBM "No further splits" warnings but keep standard output
+        p.pop("verbose", None)
+        p.setdefault("verbosity", 0)
         p.update(task_args["LGB"])
         return p
 

--- a/training_pipeline/pipeline_main.py
+++ b/training_pipeline/pipeline_main.py
@@ -112,7 +112,7 @@ class TrainingPipeline:
 
         defaults = {
             "XGB": ["n_estimators", "max_depth", "learning_rate", "subsample", "colsample_bytree",
-                    "tree_method", "device", "use_label_encoder", "eval_metric"],
+                    "tree_method", "device", "eval_metric"],
             "LGB": ["n_estimators", "max_depth", "learning_rate", "num_leaves", "device_type"],
             "CAT": ["iterations", "depth", "learning_rate", "task_type", "devices"],
             "RF":  ["n_estimators", "max_depth"],


### PR DESCRIPTION
## Summary
- Set pipeline RNG seed to 100 and propagate to LightGBM
- Allow deeper LightGBM trees with `min_child_samples=1`
- Default LightGBM verbosity to 0 to silence split warnings
- Restore tuned multiclass model parameters for XGB, LGB, CAT, RF, and ET
- Drop deprecated `use_label_encoder` from XGBoost configs
- Force XGBoost to run on CPU to avoid device mismatch warnings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2f6524c688320ab1234331d3b16ab

## Sourcery 总结

在训练管道和 LightGBM 中设置一致的随机种子，恢复经过调优的多类别模型参数，消除 LightGBM 的分裂警告，并从 XGBoost 配置中移除已弃用和 GPU 相关设置。

改进:
- 将管道的 RANDOM_STATE 标准化为 100，并通过 `random_state` 将其传播到 LightGBM
- 默认情况下通过设置 `verbosity` 为 0 来消除 LightGBM 的“无进一步分裂”警告
- 恢复 XGBoost、LightGBM、CatBoost、RandomForest 和 ExtraTrees 的调优多类别参数
- 移除已弃用的 `use_label_encoder`，并在模型配置中强制 XGBoost 在 CPU 上运行

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Set consistent random seed across training pipeline and LightGBM, restore tuned multiclass model parameters, silence LightGBM split warnings, and remove deprecated and GPU settings from XGBoost configs.

Enhancements:
- Standardize pipeline RANDOM_STATE to 100 and propagate it to LightGBM via random_state
- Silence LightGBM “No further splits” warnings by default by setting verbosity to 0
- Restore tuned multiclass parameters for XGBoost, LightGBM, CatBoost, RandomForest, and ExtraTrees
- Remove deprecated use_label_encoder and force XGBoost to run on CPU in model configurations

</details>