### PR TITLE
feat: add automated folder monitoring pipeline

### DIFF
--- a/ui_pages/folder_monitor_ui.py
+++ b/ui_pages/folder_monitor_ui.py
@@ -1,8 +1,11 @@
 import os
 import time
-import gzip
-import zipfile
+import pandas as pd
+import joblib
 import streamlit as st
+
+from etl_pipeliner import run_pipeline
+from notifier import notify_from_csv
 
 try:
     from watchdog.observers import Observer
@@ -46,47 +49,86 @@ class _FileMonitorHandler(FileSystemEventHandler):
         if not event.is_directory:
             self._track("modified", event.src_path)
 
+def _run_etl_and_infer(path: str, progress_bar) -> None:
+    """Run ETL pipeline and model inference on *path*."""
+    bin_model = st.session_state.get("binary_model")
+    mul_model = st.session_state.get("multi_model")
+    if not (bin_model and mul_model):
+        st.session_state.log_lines.append("Model paths not set; skipping")
+        return
+
+    base = os.path.splitext(path)[0]
+    pre_csv = base + "_preprocessed.csv"
+    fe_csv = base + "_engineered.csv"
+    try:
+        run_pipeline(
+            do_clean=False,
+            do_map=True,
+            do_fe=True,
+            clean_out=path,
+            preproc_out=pre_csv,
+            fe_out=fe_csv,
+        )
+        df = pd.read_csv(fe_csv)
+        features = [c for c in df.columns if c not in {"is_attack", "crlevel"}]
+        bin_clf = joblib.load(bin_model)
+        bin_pred = bin_clf.predict(df[features])
+        result = df.copy()
+        result["is_attack"] = bin_pred
+        mask = result["is_attack"] == 1
+        if mask.any():
+            mul_clf = joblib.load(mul_model)
+            result.loc[mask, "crlevel"] = mul_clf.predict(df.loc[mask, features])
+        report_path = base + "_report.csv"
+        result.to_csv(report_path, index=False)
+        st.session_state.generated_files.update({pre_csv, fe_csv, report_path})
+        webhook = st.session_state.get("discord_webhook", "")
+        gemini_key = st.session_state.get("gemini_key", "")
+        if webhook:
+            notify_from_csv(
+                report_path,
+                webhook,
+                gemini_key,
+                risk_levels={"3", "4"},
+                ui_log=st.write,
+            )
+        st.session_state.log_lines.append(f"Processed {path} -> {report_path}")
+        for pct in range(0, 101, 20):
+            progress_bar.progress(pct)
+            time.sleep(0.05)
+    except Exception as exc:  # pragma: no cover - processing errors
+        st.session_state.log_lines.append(f"Processing failed {path}: {exc}")
+
+
+def _cleanup_generated(hours: int, *, force: bool = False) -> None:
+    """Remove generated files older than *hours* or all if *force* is True."""
+    now = time.time()
+    to_remove = []
+    for f in list(st.session_state.get("generated_files", set())):
+        try:
+            if force or now - os.path.getmtime(f) > hours * 3600:
+                os.remove(f)
+                to_remove.append(f)
+        except OSError:
+            to_remove.append(f)
+    for f in to_remove:
+        st.session_state.generated_files.discard(f)
+        st.session_state.log_lines.append(f"Removed {f}")
+
+
 def _process_events(handler: _FileMonitorHandler, progress_bar) -> None:
-    """Process new events, reading only new data and updating UI."""
+    """Process newly detected files."""
     new_events = handler.events[len(st.session_state.get("processed_events", [])) :]
-    for ev, path in new_events:
-        # ensure file has settled for at least 5 seconds
+    for _, path in new_events:
         try:
             if time.time() - os.path.getmtime(path) < 5:
                 continue
         except OSError:
             continue
-        offset = st.session_state.file_offsets.get(path, 0)
-        data = ""
-        try:
-            if path.endswith(".gz"):
-                with gzip.open(path, "rt") as f:
-                    text = f.read()
-                data = text[offset:]
-                st.session_state.file_offsets[path] = len(text)
-            elif path.endswith(".zip"):
-                with zipfile.ZipFile(path) as z:
-                    text = ""
-                    for name in z.namelist():
-                        with z.open(name) as f:
-                            text += f.read().decode("utf-8")
-                data = text[offset:]
-                st.session_state.file_offsets[path] = len(text)
-            else:
-                with open(path, "r") as f:
-                    f.seek(offset)
-                    data = f.read()
-                    st.session_state.file_offsets[path] = f.tell()
-        except Exception as exc:  # pragma: no cover - file reading errors
-            st.session_state.log_lines.append(f"Error reading {path}: {exc}")
+        if path in st.session_state.get("processed_files", set()):
             continue
-        if data:
-            st.session_state.log_lines.append(
-                f"{ev}: {path} ({len(data.splitlines())} new lines)"
-            )
-            for pct in range(0, 101, 20):
-                progress_bar.progress(pct)
-                time.sleep(0.05)
+        _run_etl_and_infer(path, progress_bar)
+        st.session_state.setdefault("processed_files", set()).add(path)
     st.session_state.processed_events = handler.events[:]
 
 def app() -> None:
@@ -108,27 +150,36 @@ def app() -> None:
         st.session_state.observer = None
         st.session_state.handler = None
     st.session_state.setdefault("log_lines", [])
-    st.session_state.setdefault("file_offsets", {})
     st.session_state.setdefault("processed_events", [])
+    st.session_state.setdefault("generated_files", set())
 
     col1, col2 = st.columns([3, 1])
     with col1:
-
         st.text_input("Folder to monitor", key="folder_input")
-
     with col2:
         if st.button("Browse", disabled=tk is None or filedialog is None):
             root = tk.Tk()
             root.withdraw()
             selected = filedialog.askdirectory()
             if selected:
-
                 st.session_state.folder_input = selected
                 st.session_state.folder = selected
                 st.experimental_rerun()
     folder = st.session_state.folder_input
     st.session_state.folder = folder
 
+
+    st.text_input("Binary model path", key="binary_model")
+    st.text_input("Multiclass model path", key="multi_model")
+    retention = st.number_input(
+        "Auto clear generated files older than (hours, 0=off)",
+        min_value=0,
+        value=0,
+        step=1,
+        key="cleanup_hours",
+    )
+    if st.button("Clear generated files now"):
+        _cleanup_generated(0, force=True)
 
     if Observer is None:
         st.error("watchdog is not installed")
@@ -158,6 +209,7 @@ def app() -> None:
 
     if st.session_state.observer is not None:
         _process_events(st.session_state.handler, progress_bar)
+        _cleanup_generated(retention)
         log_placeholder.text("\n".join(st.session_state.log_lines))
         time.sleep(1)
         st.experimental_rerun()


### PR DESCRIPTION
## Summary
- extend folder monitor to run ETL, model inference, and optional notifications when new log files arrive
- allow specifying binary/multiclass models and automatically clean generated artifacts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b42aad028c832081993980abea0b73

## Sourcery 总结

添加一个端到端的自动化文件夹监控管道，该管道在新日志文件上运行 ETL、特征工程和模型推理，生成带有可选通知的报告，并管理生成的工件。

新功能：
- 自动触发对新检测到的日志文件进行 ETL、特征工程以及二分类/多分类模型推理。
- 暴露 UI 控件，用于指定二分类和多分类模型路径、设置保留小时数以及手动清除生成的文件。
- 使用可选的 gemini 密钥，通过 Discord webhook 发送基于风险的通知。
- 实现根据保留设置或强制删除，自动清理生成的预处理文件、工程化文件和报告文件。

改进：
- 通过移除手动文件偏移量跟踪并使用 `processed_files` 集合来避免重复处理，从而简化事件处理。
- 在 UI 中，在处理和清理过程中提供进度反馈。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an end-to-end automated folder monitoring pipeline that runs ETL, feature engineering, and model inference on new log files, generates reports with optional notifications, and manages generated artifacts.

New Features:
- Automatically trigger ETL, feature engineering, and binary/multiclass model inference on newly detected log files.
- Expose UI controls for specifying binary and multiclass model paths, setting retention hours, and manually clearing generated files.
- Send risk-based notifications via Discord webhook using optional gemini key.
- Implement automated cleanup of generated preprocessing, engineered, and report files based on retention settings or force deletion.

Enhancements:
- Simplify event processing by removing manual file offset tracking and using a processed_files set to avoid reprocessing.
- Provide progress feedback during processing and cleanup in the UI.

</details>