### PR TITLE
Add LINE notifications and feature consistency checks

### DIFF
--- a/ui_app.py
+++ b/ui_app.py
@@ -93,7 +93,7 @@ PAGE_DESCRIPTIONS = {
     "Model Inference": "Perform inference using trained models.",
     "Folder Monitor": "Watch a directory for CSV/TXT/log files, including compressed variants.",
     "Visualization": "Explore dataset and model outputs through charts.",
-    "Notifications": "Send Discord alerts with Gemini-generated advice.",
+    "Notifications": "Send Discord/LINE alerts with Gemini-generated advice.",
 }
 
 page_keys = list(PAGES.keys())

--- a/ui_pages/folder_monitor_ui.py
+++ b/ui_pages/folder_monitor_ui.py
@@ -75,28 +75,42 @@ def _run_etl_and_infer(path: str, progress_bar) -> None:
         features = [c for c in df.columns if c not in {"is_attack", "crlevel"}]
 
         bin_clf = bin_model
-
-        bin_pred = bin_clf.predict(df[features])
+        bin_features = list(getattr(bin_clf, "feature_names_in_", features))
+        missing = [f for f in bin_features if f not in df.columns]
+        if missing:
+            st.session_state.log_lines.append(
+                f"Missing features for binary model: {missing}"
+            )
+            return
+        bin_pred = bin_clf.predict(df[bin_features])
         result = df.copy()
         result["is_attack"] = bin_pred
         mask = result["is_attack"] == 1
         if mask.any():
 
             mul_clf = mul_model
-
-            result.loc[mask, "crlevel"] = mul_clf.predict(df.loc[mask, features])
+            mul_features = list(getattr(mul_clf, "feature_names_in_", features))
+            missing_mul = [f for f in mul_features if f not in df.columns]
+            if missing_mul:
+                st.session_state.log_lines.append(
+                    f"Missing features for multiclass model: {missing_mul}"
+                )
+                return
+            result.loc[mask, "crlevel"] = mul_clf.predict(df.loc[mask, mul_features])
         report_path = base + "_report.csv"
         result.to_csv(report_path, index=False)
         st.session_state.generated_files.update({pre_csv, fe_csv, report_path})
         webhook = st.session_state.get("discord_webhook", "")
         gemini_key = st.session_state.get("gemini_key", "")
-        if webhook:
+        line_token = st.session_state.get("line_token", "")
+        if webhook or line_token:
             notify_from_csv(
                 report_path,
                 webhook,
                 gemini_key,
                 risk_levels={"3", "4"},
                 ui_log=st.write,
+                line_token=line_token,
             )
         st.session_state.log_lines.append(f"Processed {path} -> {report_path}")
         for pct in range(0, 101, 20):


### PR DESCRIPTION
## Summary
- add LINE messaging support with user management and integrate into notification pipeline
- expose LINE webhook settings in notification UI and folder monitor
- ensure inference uses same feature set as trained models

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b45cb30bdc8320994c85d2db5ccd49

## Sourcery 总结

添加端到端 LINE 通知支持，与现有 Discord 警报并行；在用户界面中显示 LINE 设置；并强制训练和推理之间的特征一致性，以防止模型输入不匹配

新功能：
- 添加 LINE 消息支持，包括用户管理，并将其集成到通知管道中
- 在通知 UI 和文件夹监控 UI 中公开 LINE Channel Access Token，并带有一个测试通知按钮

改进：
- 通过验证 `feature_names_in_` 并在预测前记录缺失特征，确保推理使用与训练模型相同的特征集

测试：
- 添加通过 `notify_from_csv` 发送 LINE 通知的功能测试

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add end-to-end LINE notification support alongside existing Discord alerts, surface LINE settings in the UI, and enforce feature consistency between training and inference to prevent model input mismatches

New Features:
- Add LINE messaging support with user management and integrate it into the notification pipeline
- Expose LINE Channel Access Token in the notification UI and folder monitor UI with a test notification button

Enhancements:
- Ensure inference uses the same feature set as trained models by validating feature_names_in_ and logging missing features before prediction

Tests:
- Add tests for sending LINE notifications via notify_from_csv

</details>