### PR TITLE
Fix FutureWarning by dtype-aware NaN fill

### DIFF
--- a/ui_pages/folder_monitor_ui.py
+++ b/ui_pages/folder_monitor_ui.py
@@ -105,7 +105,11 @@ def _run_etl_and_infer(path: str, progress_bar) -> None:
         # original data retained for notification context
         raw_df = pd.read_csv(path)
         if raw_df.isna().any().any():
-            raw_df.fillna("", inplace=True)
+            fill_values = {
+                col: 0 if pd.api.types.is_numeric_dtype(raw_df[col]) else ""
+                for col in raw_df.columns
+            }
+            raw_df.fillna(value=fill_values, inplace=True)
 
 
         features = [c for c in df.columns if c not in {"is_attack", "crlevel"}]


### PR DESCRIPTION
## Summary
- avoid pandas FutureWarning by filling NaNs with dtype-appropriate defaults in folder monitor UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b47b20a208832085410a931760caab