### PR TITLE
refactor: separate report visualization

### DIFF
--- a/ui_pages/visualization_ui.py
+++ b/ui_pages/visualization_ui.py
@@ -5,10 +5,27 @@ _ensure_module("pandas", "pandas_stub")
 import pandas as pd
 import matplotlib.pyplot as plt
 
+
+def _pie_chart(ax, counts, colors):
+    ax.pie(
+        counts.values,
+        labels=counts.index.astype(str),
+        colors=colors,
+        autopct="%1.1f%%",
+        pctdistance=0.8,
+        labeldistance=1.1,
+        textprops={"fontsize": 10},
+        startangle=90,
+    )
+    ax.axis("equal")
+
+
 def app() -> None:
     st.title("Prediction Visualization")
-    df = st.session_state.get("prediction_results")
-    if df is None:
+    counts = st.session_state.get("last_counts")
+    report_path = st.session_state.get("last_report_path")
+    if counts is None:
+        st.info("No processed data available. Use the Folder Monitor to generate a report.")
         uploaded = st.file_uploader(
             "Upload prediction CSV",
             type=["csv"],
@@ -16,25 +33,44 @@ def app() -> None:
         )
         if uploaded is not None:
             df = pd.read_csv(uploaded)
-            st.session_state["prediction_results"] = df
-    if df is None:
-        st.info("No prediction results available")
+            counts = {
+                "is_attack": df["is_attack"].value_counts().reindex([0, 1], fill_value=0),
+                "crlevel": df["crlevel"].value_counts().reindex([0, 1, 2, 3, 4], fill_value=0)
+                if "crlevel" in df.columns
+                else pd.Series(dtype=int),
+            }
+            st.session_state["last_counts"] = counts
+            report_path = uploaded.name
+    if counts is None:
         return
-    st.subheader("is_attack distribution")
-    is_counts = df["is_attack"].value_counts().reindex([0, 1], fill_value=0)
-    fig, ax = plt.subplots()
-    ax.bar(is_counts.index.astype(str), is_counts.values, color=["green", "red"])
-    st.pyplot(fig)
+    if report_path:
+        st.write(f"Showing results for: {report_path}")
+    bin_colors = ["green", "red"]
+    mul_colors = ["green", "yellowgreen", "gold", "orange", "red"]
+    col1, col2 = st.columns(2)
+    with col1:
+        st.subheader("Binary distribution (bar)")
+        fig, ax = plt.subplots(figsize=(4, 3))
+        ax.bar(counts["is_attack"].index.astype(str), counts["is_attack"].values, color=bin_colors)
+        st.pyplot(fig, use_container_width=True)
+    with col2:
+        st.subheader("Binary distribution (pie)")
+        fig, ax = plt.subplots(figsize=(4, 3))
+        _pie_chart(ax, counts["is_attack"], bin_colors)
+        st.pyplot(fig, use_container_width=True)
+    col3, col4 = st.columns(2)
+    with col3:
+        st.subheader("crlevel distribution (bar)")
+        fig, ax = plt.subplots(figsize=(4, 3))
+        ax.bar(counts["crlevel"].index.astype(str), counts["crlevel"].values, color=mul_colors)
+        st.pyplot(fig, use_container_width=True)
+    with col4:
+        st.subheader("crlevel distribution (pie)")
+        fig, ax = plt.subplots(figsize=(4, 3))
+        _pie_chart(ax, counts["crlevel"], mul_colors)
+        st.pyplot(fig, use_container_width=True)
 
-    if "crlevel" in df.columns:
-        counts = df["crlevel"].value_counts().reindex([0, 1, 2, 3, 4], fill_value=0)
-        st.subheader("crlevel distribution (vertical)")
-        fig_v, ax_v = plt.subplots()
-        colors = ["green", "yellowgreen", "gold", "orange", "red"]
-        ax_v.bar(counts.index.astype(str), counts.values, color=colors)
-        st.pyplot(fig_v)
-
-        st.subheader("crlevel distribution (horizontal)")
-        fig_h, ax_h = plt.subplots()
-        ax_h.barh(counts.index.astype(str), counts.values, color=colors)
-        st.pyplot(fig_h)
+    critical = st.session_state.get("last_critical")
+    if critical is not None and not critical.empty:
+        st.subheader("Critical traffic (crlevel ≥ 4)")
+        st.dataframe(critical)


### PR DESCRIPTION
## Summary
- Notify users in folder monitor when a report is generated and direct them to the visualization page
- Move classification charts to visualization page with a 2x2 layout and improved pie label spacing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b51e16f0b88320b596b29dcbaccb01

## Sourcery 摘要

将报告可视化分离到独立的 UI 页面，并在报告生成时通知用户

增强功能：
- 引入可复用的 `_pie_chart` 辅助函数，以实现一致的饼图渲染
- 重构可视化 UI，以 2×2 的条形图和饼图布局显示二元和多类别分布，并改进了间距
- 将分类图表逻辑从文件夹监控 UI 移至专用的可视化页面
- 在可视化页面显示生成的报告文件名和关键流量表
- 在文件夹监控 UI 中通知用户报告已生成，并将其路径存储在会话状态中

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Separate report visualization into its own UI page and notify users upon report generation

Enhancements:
- Introduce a reusable _pie_chart helper for consistent pie chart rendering
- Restructure visualization UI to display binary and multi-class distributions in a 2×2 bar and pie layout with improved spacing
- Move classification chart logic out of the folder monitor UI and into the dedicated visualization page
- Display the generated report filename and critical traffic table on the visualization page
- Notify users in the folder monitor UI when a report is generated and store its path in session state

</details>