### PR TITLE
Fix cupy stub missing ndarray attribute

### DIFF
--- a/ui_pages/cupy_stub.py
+++ b/ui_pages/cupy_stub.py
@@ -4,7 +4,22 @@ The real project only relies on a tiny subset of the Cupy API.  When Cupy
 isn't installed we provide drop-in functions that simply return the original
 Python objects so the rest of the code can fall back to CPU execution without
 raising attribute errors.
+
+Dask inspects ``cupy.ndarray`` when optional GPU support is enabled.  The
+stub therefore exposes a lightweight placeholder ``ndarray`` type so that
+imports touching :mod:`dask.array` keep working even though the actual Cupy
+package is missing.
 """
+
+
+class ndarray:  # pragma: no cover - behaviour is trivial
+    """Placeholder for :class:`cupy.ndarray`.
+
+    The class intentionally has no behaviour; it only needs to exist so that
+    libraries performing ``hasattr(cupy, "ndarray")`` or ``isinstance``
+    checks do not fail when Cupy is stubbed out.
+    """
+
 
 def array(obj):
     return obj
@@ -19,5 +34,5 @@ def asnumpy(obj):
     return obj
 
 
-__all__ = ["array", "asarray", "asnumpy"]
+__all__ = ["array", "asarray", "asnumpy", "ndarray"]
 


### PR DESCRIPTION
## Summary
- add a lightweight `ndarray` placeholder to the cupy stub so optional Dask imports succeed when Cupy is absent
- expose the placeholder via ``__all__`` and document why it exists

## Testing
- pytest tests/test_cupy_stub.py

------
https://chatgpt.com/codex/tasks/task_e_68d0afad30508320a8f7c02055731a6a

## Sourcery 总结

在 cupy 存根中提供一个轻量级的 ndarray 占位符，以防止在 Cupy 缺失时出现属性错误，并确保可选的 Dask 导入继续正常工作。

Bug 修复：
- 为 cupy.ndarray 添加一个存根类，以避免在 Cupy 未安装时出现属性缺失错误

改进：
- 在 `__all__` 中暴露 ndarray 占位符，以保持公共 API 的一致性

文档：
- 记录 cupy 存根中 ndarray 占位符的目的和行为

测试：
- 为 `cupy_stub` 添加测试，以验证占位符 ndarray 和存根函数的行为符合预期

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Provide a lightweight ndarray placeholder in the cupy stub to prevent attribute errors when Cupy is missing and ensure optional Dask imports continue to work.

Bug Fixes:
- Add a stub class for cupy.ndarray to avoid missing attribute errors when Cupy is not installed

Enhancements:
- Expose the ndarray placeholder in __all__ for public API consistency

Documentation:
- Document the purpose and behavior of the ndarray placeholder in the cupy stub

Tests:
- Add tests for the cupy_stub to verify the placeholder ndarray and stub functions behave as expected

</details>